### PR TITLE
Only add consecs to incorporated states

### DIFF
--- a/Urban Synergy Unleashed/common/history/global/MoG_consec_balancer.txt
+++ b/Urban Synergy Unleashed/common/history/global/MoG_consec_balancer.txt
@@ -4,6 +4,8 @@ GLOBAL = {
 		limit = { Grey_USU_is_active = yes }
 		every_state = {
 			limit = {
+				is_incorporated = yes
+				is_treaty_port = no
 				has_potential_resource = bg_iron_mining
 				owner ?= { NOT = { is_country_type = decentralized } }
 			}


### PR DESCRIPTION
This should avoid some instances of consecs being placed in states that lack the population to support them.
This is particularly relevant in 1.8, since with low MAPI the added consecs are creating some local famines at game start by pulling too many workers away from grain production.
There may also be some problematic incorporated states, but it's probably less of an issue without the unincorporated MAPI modifier