### PR TITLE
Apparently tiny landlocked countries need help with their logistics PMs

### DIFF
--- a/Urban Synergy Unleashed/common/production_methods/yMoG_USU_rail_other_pms.txt
+++ b/Urban Synergy Unleashed/common/production_methods/yMoG_USU_rail_other_pms.txt
@@ -14,6 +14,7 @@ USU_pm_rail_logistics_1 = {
 			goods_output_usu_logistics_add = 8
 		}
 	}
+	ai_weight = 1000
 }
 
 USU_pm_rail_logistics_2 = {
@@ -26,6 +27,7 @@ USU_pm_rail_logistics_2 = {
 			goods_output_usu_logistics_add = 20
 		}
 	}
+	ai_weight = 2000
 }
 
 USU_pm_rail_logistics_3 = {
@@ -42,6 +44,7 @@ USU_pm_rail_logistics_3 = {
 			goods_output_usu_logistics_add = 30
 		}
 	}
+	ai_weight = 3000
 }
 
 ### Passenger Carriages


### PR DESCRIPTION
I think the profit difference between the PMs is too small for the normal "most profitable PM" check to get micro states to switch. Landlocked microstates then end up with a logistics shortage once they've depeasented.