### PR TITLE
discrimination and movement tweaks

### DIFF
--- a/Populist Legal Power/common/defines/yMog_PLP_defines.txt
+++ b/Populist Legal Power/common/defines/yMog_PLP_defines.txt
@@ -1,0 +1,12 @@
+NPops = {
+    RADICALS_MAX_FROM_LOW_SOL = 0.25 # 0.15				# If pop is already this % radical, don't add more radicals from low SOL (Scales by delta between SoL and expected min SoL)
+	RADICALS_MAX_FROM_DISCRIMINATION = 0.7 # 0.5		# If pop is already this % radical, don't add more radicals from discrimination (Scales by literacy)
+}
+
+NPolitics = {
+    #MOVEMENT_WEEKLY_RADICALISM_CHANGE = 0.01 # How much does a movement's radicalism change towards its calculated target each week
+	MOVEMENT_MONTHLY_RADICALS_THRESHOLD = 0.25 # 0.5 # At this level of radicalism, movement supporters start being radicalized each month at an amount scaled by the radicalism value
+	#MOVEMENT_MONTHLY_RADICALS_SCALING_MIN = 0.005 # The minimum % of supporters radicalized each month when above the radicalization threshold
+	#MOVEMENT_MONTHLY_RADICALS_SCALING_MAX = 0.025 # The maximum % of supporters radicalized each month when above the radicalization threshold 
+	#MOVEMENT_LOYALISTS_ON_APPROVED_ENACTMENT = 0.25 # The % of supporters who become more loyal when a law the movement approves of is enacted
+}

--- a/Populist Legal Power/common/laws/yMoG_PLP_citizenship.txt
+++ b/Populist Legal Power/common/laws/yMoG_PLP_citizenship.txt
@@ -1,4 +1,4 @@
-﻿# group = this is the law_group a law belongs to
+# group = this is the law_group a law belongs to
 # icon = graphical icon shown in-game
 # modifier = {} modifier on country for having adopted this law
 

--- a/Populist Legal Power/common/political_movements/yMog_PLP_cultural_movement.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_cultural_movement.txt
@@ -72,8 +72,17 @@
 
 	disband_trigger = {
 		scope:political_movement ?= {
-			culture = {
-				is_primary_culture_of = root
+			OR = {
+				culture = {
+					is_primary_culture_of = root
+				}
+				root = {
+					NOT = { any_scope_state = { state_region = { is_homeland = scope:political_movement.culture } } }
+					culture_percent_country = {
+						target = scope:political_movement.culture
+						value <= 0.04
+					}
+				}
 			}
 		}
 	}
@@ -406,6 +415,10 @@
 			owner ?= {
 				any_scope_state = {
 					state_region = { is_homeland = root.culture }
+					culture_percent_state = {
+						target = root.culture
+						value >= 0.05
+					}					
 				}
 			}
 		}
@@ -421,8 +434,12 @@
 				limit = { 
 					is_capital = no
 					state_region = { is_homeland = scope:political_movement.culture }
+					culture_percent_state = {
+						target = scope:political_movement.culture
+						value >= 0.05
+					}					
 				}
-				add = 50
+				add = 10
 
 				if = {
 					limit = {
@@ -431,7 +448,7 @@
 							value >= 0.75
 						}
 					}
-					add = 250
+					add = 1000
 				}
 				else_if = {
 					limit = {
@@ -440,7 +457,7 @@
 							value >= 0.5
 						}
 					}
-					add = 150
+					add = 500
 				}
 				else_if = {
 					limit = {
@@ -449,7 +466,7 @@
 							value >= 0.25
 						}
 					}
-					add = 50
+					add = 100
 				}
 				else_if = {
 					limit = {
@@ -458,7 +475,7 @@
 							value >= 0.1
 						}
 					}
-					add = 10
+					add = 50
 				}
 			}				
 		}

--- a/Populist Legal Power/common/political_movements/yMog_PLP_cultural_movement.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_cultural_movement.txt
@@ -1,0 +1,528 @@
+﻿movement_cultural_minority = {
+	category = movement_category_cultural
+		
+	ideology = ideology_pluralist_movement_1
+	character_ideologies = {
+		ideology_reformer
+	}
+	
+	creation_trigger = {}
+	creation_weight = {
+		value = 50
+		if = {
+			limit = {
+				owner ?= {
+					has_technology_researched = nationalism
+				}
+			}
+			multiply = {
+				value = 2
+			}
+		}
+		if = {
+			limit = {
+				owner ?= {
+					has_variable = failed_tanzimat
+				}
+			}
+			multiply = {
+				value = 2
+			}
+		}
+		if = {
+			limit = {
+				owner ?= {
+					has_journal_entry = je_springtime_of_the_peoples
+				}
+			}
+			multiply = {
+				value = 2
+			}
+		}
+	}
+	on_created = {
+		if = {
+			limit = {
+				culture = {
+					shares_heritage_and_other_trait_with_any_primary_culture = root.owner
+				}
+			}
+			set_core_ideology = ideology_pluralist_movement_1
+		}
+		else_if = {
+			limit = {
+				culture = {
+					shares_heritage_trait_with_any_primary_culture = root.owner
+				}
+			}
+			set_core_ideology = ideology_pluralist_movement_2
+		}
+		else_if = {
+			limit = {
+				culture = {
+					shares_non_heritage_trait_with_any_primary_culture = root.owner
+				}
+			}
+			set_core_ideology = ideology_pluralist_movement_3
+		}
+		else = {
+			set_core_ideology = ideology_pluralist_movement_4
+		}
+	}
+
+	disband_trigger = {
+		scope:political_movement ?= {
+			culture = {
+				is_primary_culture_of = root
+			}
+		}
+	}
+	
+	culture_selection_trigger = {
+		NOT = { is_primary_culture_of = scope:country }
+		scope:country = {
+			OR = {
+				any_scope_state = { state_region = { is_homeland = root } }
+				culture_percent_country = {
+					target = root
+					value >= 0.05
+				}
+			}
+		}
+	}	
+	culture_selection_weight = {
+		value = 100
+	}
+	
+	character_support_trigger = {	
+		culture = scope:culture
+		OR = {
+			has_ideology = ideology:ideology_humanitarian		
+			has_ideology = ideology:ideology_humanitarian_royalist	
+			has_ideology = ideology:ideology_sovereignist_leader			
+			has_ideology = ideology:ideology_reformer		
+		}		
+	}
+	character_support_weight = {
+		value = 200
+		if = {
+			limit = {
+				has_ideology = ideology:ideology_sovereignist_leader
+			}
+			multiply = {
+				value = 5
+			}
+		}
+		else_if = {
+			limit = {
+				OR = {
+					has_ideology = ideology:ideology_humanitarian
+					has_ideology = ideology:ideology_reformer
+				}
+			}
+			multiply = {
+				value = 2
+			}
+		}
+	}
+	
+	pop_support_trigger = {
+		culture = scope:culture
+	}
+
+	pop_support_factors = {
+		movement_support_high_literacy
+		movement_support_cultural_discrimination
+		movement_support_je_sick_man_main
+		movement_support_je_dual_monarchy
+		movement_support_aristocrats_polish
+		movement_support_academics
+		movement_support_clergymen
+		movement_support_clerks
+		movement_support_soldiers
+		movement_support_nationalism_tech
+		movement_support_pan_nationalism_tech
+	}
+	
+	pop_support_weight = {
+		add = {
+			value = 10
+			desc = "POP_BASE_SUPPORT"
+		}	
+		
+		if = {
+			limit = {
+				strata = upper
+			}
+			if = {
+				limit = {
+					culture = cu:polish
+					is_pop_type = aristocrats
+					state ?= {
+						OR = {
+							has_variable = lingering_plc_resistance
+							has_variable = christ_of_nations_target
+						}
+					}
+				}
+				add = {
+					value = 100
+					desc = "POP_POLISH_ARISTOCRATS"
+				}
+			}
+			else_if = {
+				limit = {
+					culture = cu:hungarian
+					is_pop_type = aristocrats
+					owner ?= {
+						has_journal_entry = je_dual_monarchy
+					}
+				}
+				add = {
+					value = 100
+					desc = "je_dual_monarchy"
+				}
+			}
+			else = {
+				value = 6
+				desc = "UPPER_NO_ICON"
+			}
+		}
+		else_if = {
+			limit = {
+				strata = middle
+			}
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				add = {
+					value = 35
+					desc = "POP_ACADEMICS"
+				}
+			}
+			else_if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				add = {
+					value = 25
+					desc = "POP_CLERGYMEN"
+				}
+			}
+			else = {
+				add = {
+					value = 10
+					desc = "MIDDLE_NO_ICON"
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				strata = lower
+			}
+			if = {
+				limit = {
+					is_pop_type = clerks
+				}
+				add = {
+					value = 10
+					desc = "POP_CLERKS"
+				}
+			}
+			else_if = {
+				limit = {
+					is_pop_type = soldiers
+				}
+				add = {
+					value = 9
+					desc = "POP_SOLDIERS"
+				}
+			}
+			else = {
+				add = {
+					value = 5
+					desc = "LOWER_NO_ICON"
+				}
+			}
+		}
+		
+		if = {
+			limit = { 
+				standard_of_living < 15
+			}
+			
+			add = {
+				value =	standard_of_living
+				subtract = 15
+				multiply = -5
+				desc = "POP_POVERTY"
+			}
+		}
+
+		# Actual conditions relative to their neighbors
+		multiply = {
+			value = 1.0
+			add = {
+				#value = "owner.average_sol"
+				value = "owner.average_sol_for_primary_cultures"
+				subtract = "owner.average_sol_for_culture(scope:culture)"
+				multiply = 0.05
+			}
+			desc = "STANDARD_OF_LIVING_FOR_CULTURE"
+		}
+
+		if = {
+			limit = {
+				state = {
+					state_cultural_acceptance = {  
+						target = PREV.culture
+						value < acceptance_status_5
+					}	
+				}
+			}
+			
+			multiply = {
+				desc = "POP_DISCRIMINATED"	
+				value = 100
+				subtract = pop_acceptance			
+				divide = 25	
+			}			
+		}
+		else = { # Non-discriminated pops are less likely to form separatist movements
+			multiply = {
+				desc = "POP_ACCEPTANCE"	
+				value = 0.10
+			}			
+		}
+		
+		if = {
+			limit = {
+				culture = cu:polish
+				state ?= {
+					OR = {
+						has_variable = lingering_plc_resistance
+						has_variable = christ_of_nations_target
+					}
+				}
+			}
+			multiply = { # Illiterate pops participate at 1/3 the rate of fully literate pops
+				desc = "POP_LITERACY"
+				value = literacy_rate
+				add = 0.33
+			}
+		}
+		else = {
+			multiply = { # Illiterate pops participate at 1/8 the rate of fully literate pops
+				desc = "POP_LITERACY"
+				value = literacy_rate
+				add = 0.15
+			}
+		}
+
+		if = {
+			limit = {
+				owner ?= {
+					has_technology_researched = nationalism
+				}
+			}
+			multiply = {
+				value = 2.0
+				desc = "NATIONALISM_TECH"
+			}
+		}
+		if = {
+			limit = {
+				owner ?= {
+					has_technology_researched = pan-nationalism
+				}
+			}
+			multiply = {
+				value = 1.5
+				desc = "PAN_NATIONALISM_TECH"
+			}
+		}
+
+		if = { # Funnel people into Indias unique movements
+			limit = {
+				owner ?= {
+					c:BIC ?= this
+				}
+				culture = { has_discrimination_trait = south_asian_heritage }
+			}
+			multiply = 0.5
+
+			if = {
+				limit = {
+					owner ?= {
+						has_technology_researched = pan-nationalism
+					}
+				}
+				multiply = 0.1
+			}
+		}
+		
+		if = {
+			limit = {
+				owner ?= {
+					has_variable = failed_tanzimat
+				}
+				culture = { has_discrimination_trait = european_heritage }
+			}
+			multiply = {
+				value = 2.0
+				desc = "FAILED_TANZIMAT_REFORMS"
+			}
+		}
+
+		if = {
+			limit = {
+				owner ?= {
+					has_journal_entry = je_dual_monarchy
+				}
+				culture = cu:hungarian
+			}
+			multiply = {
+				value = 2.0
+				desc = "je_dual_monarchy"
+			}
+		}
+
+		if = {
+			limit = { 
+				owner ?= { has_journal_entry = je_springtime_of_the_peoples } 
+				culture = { has_discrimination_trait = european_heritage }
+			}
+			multiply = {
+				value = 2.0
+				desc = "SPRINGTIME_OF_THE_PEOPLES_UNDERWAY"
+			}
+		}
+	}	
+	
+	secession = {
+		possible = {
+			political_movement_identity_support >= 0.25
+			owner ?= {
+				any_scope_state = {
+					state_region = { is_homeland = root.culture }
+				}
+			}
+		}
+	
+		weight = {
+			value = 1000		
+		}	
+		
+		state_weight = {
+			value = 0
+		
+			if = {
+				limit = { 
+					is_capital = no
+					state_region = { is_homeland = scope:political_movement.culture }
+				}
+				add = 50
+
+				if = {
+					limit = {
+						culture_percent_state = {
+							target = scope:political_movement.culture
+							value >= 0.75
+						}
+					}
+					add = 250
+				}
+				else_if = {
+					limit = {
+						culture_percent_state = {
+							target = scope:political_movement.culture
+							value >= 0.5
+						}
+					}
+					add = 150
+				}
+				else_if = {
+					limit = {
+						culture_percent_state = {
+							target = scope:political_movement.culture
+							value >= 0.25
+						}
+					}
+					add = 50
+				}
+				else_if = {
+					limit = {
+						culture_percent_state = {
+							target = scope:political_movement.culture
+							value >= 0.1
+						}
+					}
+					add = 10
+				}
+			}				
+		}
+
+		target_fraction_of_states = {
+			value = political_movement_identity_support
+			add = scope:clout
+			multiply = 3
+			min = 0.15
+			max = 0.75
+		}
+	}
+	
+	additional_radicalism_factors = {
+		if = {
+			limit = { 
+				owner = { has_journal_entry = je_springtime_of_the_peoples } 
+				scope:culture = { has_discrimination_trait = european_heritage }
+			}
+			add = {
+				value = 0.25
+				desc = "SPRINGTIME_OF_THE_PEOPLES_UNDERWAY"
+			}
+		}	
+	
+		add = {
+			#value = "owner.average_sol"
+			value = "owner.average_sol_for_primary_cultures"
+			subtract = "owner.average_sol_for_culture(scope:culture)"
+			multiply = 0.05
+			max = 0.5
+			min = 0
+			desc = "STANDARD_OF_LIVING_FOR_CULTURE"
+		}
+		
+		if = {
+			limit = {
+				owner = { cultural_acceptance_base = { target = scope:culture value <= acceptance_status_1 } }
+			}
+			
+			add = {
+				value = 0.3	
+				desc = "DISCRIMINATION_LEVEL_violent_hostility"
+			}			
+		}
+		else_if = {
+			limit = {
+				owner = { cultural_acceptance_base = { target = scope:culture value <= acceptance_status_2 } }
+			}
+			
+			add = {
+				value = 0.2
+				desc = "DISCRIMINATION_LEVEL_cultural_erasure"
+			}			
+		}
+		else_if = {
+			limit = {
+				owner = { cultural_acceptance_base = { target = scope:culture value <= acceptance_status_3 } }
+			}
+			
+			add = {
+				value = 0.1
+				desc = "DISCRIMINATION_LEVEL_open_prejudice"
+			}
+		}	
+	}
+}

--- a/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
@@ -154,47 +154,6 @@
 				}
 			}
 		}
-
-		if = {
-			limit = {
-                this.culture = {
-                    any_scope_pop = {
-                        owner = root.owner
-                        is_pop_type = slaves
-                    }
-                }
-			}
-			multiply = {
-				desc = "CULTURE_ENSLAVED_PERCENT" # TODO: "x percent of this culture is enslaved"
-				value = 1
-
-				add = {
-					value = {
-						value = 0
-						this.culture = {
-							every_scope_pop = {
-								limit = {
-									owner = root.owner
-									is_pop_type = slaves
-								}
-								add = total_size
-							}
-						}
-					}
-					divide = {
-						value = 0
-						this.culture = {
-							every_scope_pop = {
-								limit = {
-									owner = root.owner
-								}
-								add = total_size
-							}
-						}
-					}
-				}
-			}
-		}
 		
 		multiply = {
 			desc = "SLAVE_STATE"
@@ -231,6 +190,69 @@
 			multiply = {
 				value = 3.0
 				desc = "je_acw_countdown"
+			}
+		}
+
+		if = {
+			limit = {
+				owner = {
+					or = {
+						has_law = law_type:law_slave_trade
+						has_law = law_type:law_legacy_slavery
+					}
+				}
+                this.culture = {
+                    any_scope_pop = {
+                        owner = root.owner
+                        is_pop_type = slaves
+                    }
+                }
+			}
+			add = {
+				desc = "CULTURE_ENSLAVED_PERCENT" # TODO: "x percent of this culture is enslaved"
+				value = 100
+
+				multiply = {
+					value = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+									is_pop_type = slaves
+								}
+								add = total_size
+							}
+						}
+					}
+					divide = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+								}
+								add = total_size
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				standard_of_living < 15
+				owner = {
+					has_law = law_type:law_debt_slavery
+				}
+			}
+			
+			add = {
+				value =	standard_of_living
+				subtract = 15
+				multiply = -5
+				desc = "POP_POVERTY"
 			}
 		}
 

--- a/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
@@ -1,0 +1,815 @@
+﻿movement_anti_slavery = {
+	category = movement_category_ideological
+
+	ideology = ideology_anti_slavery	
+	character_ideologies = {
+		ideology_abolitionist
+		ideology_humanitarian
+	}
+	
+	disband_trigger = {
+		has_law = law_type:law_slavery_banned
+	}
+	on_disbanded = {}
+	
+	creation_trigger = {
+		NOT = { has_law = law_type:law_slavery_banned }
+		has_technology_researched = empiricism
+	}
+	creation_weight = {
+		value = 100
+	}	
+	on_created = {
+		add_movement_enthusiasm_modifier = yes
+	}
+	
+	character_support_trigger = {
+		OR = {
+			has_ideology = ideology:ideology_abolitionist
+			has_ideology = ideology:ideology_humanitarian
+			OR = {
+				is_interest_group_type = ig_intelligentsia
+				is_interest_group_type = ig_trade_unions
+			}
+		}
+	}
+	character_support_weight = {
+		value = 200
+		if = {
+			limit = {
+				OR = {
+					has_ideology = ideology:ideology_abolitionist
+					has_ideology = ideology:ideology_humanitarian
+				}
+			}
+			multiply = {
+				value = 5
+			}
+		}
+	}
+	
+	pop_support_factors = {
+		movement_support_high_urbanization
+		movement_support_high_literacy	
+		movement_support_capitalists
+		movement_support_academics
+		movement_support_clergymen
+		movement_support_bureaucrats
+		movement_support_clerks
+		movement_support_slaves
+		movement_support_je_acw_countdown
+	}	
+
+	pop_support_weight = {
+		add = {
+			desc = "URBAN_STATE"
+			value = 3
+			multiply = state.state_urbanization_rate
+		}
+
+		if = {
+			limit = {
+				strata = upper
+			}
+			if = {
+				limit = {
+					is_pop_type = capitalists
+				}
+				add = {
+					value = 12
+					desc = "POP_CAPITALISTS"
+				}
+			}
+			else = {
+				add = {
+					value = 3
+					desc = "UPPER_NO_ICON"
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				strata = middle
+			}
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				add = {
+					value = 25
+					desc = "POP_ACADEMICS"
+				}
+			}
+			else_if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				add = {
+					value = 25
+					desc = "POP_CLERGYMEN"
+				}
+			}
+			else_if = {
+				limit = {
+					is_pop_type = bureaucrats
+				}
+				add = {
+					value = 15
+					desc = "POP_BUREAUCRATS"
+				}
+			}
+			else = {
+				add = {
+					value = 10
+					desc = "MIDDLE_NO_ICON"
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				strata = lower
+			}
+			if = {
+				limit = {
+					is_pop_type = clerks
+				}
+				add = {
+					value = 10
+					desc = "POP_CLERKS"
+				}
+			}
+			else_if = {
+				limit = {
+					is_pop_type = slaves
+				}
+				add = {
+					value = 30
+					desc = "POP_SLAVES"
+				}
+			}
+			else = {
+				add = {
+					value = 3
+					desc = "LOWER_NO_ICON"
+				}
+			}
+		}
+
+		if = {
+			limit = {
+                this.culture = {
+                    any_scope_pop = {
+                        owner = root.owner
+                        is_pop_type = slaves
+                    }
+                }
+			}
+			multiply = {
+				desc = "CULTURE_ENSLAVED_PERCENT" # TODO: "x percent of this culture is enslaved"
+				value = 1
+
+				add = {
+					value = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+									is_pop_type = slaves
+								}
+								add = total_size
+							}
+						}
+					}
+					divide = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+								}
+								add = total_size
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		multiply = {
+			desc = "SLAVE_STATE"
+			value = 1.0
+			
+			if = {
+				limit = {
+					state = { is_slave_state = yes }
+				}
+				
+				if = {
+					limit = {
+						OR = {
+							is_pop_type = aristocrats
+							is_pop_type = clergymen
+							is_pop_type = officers
+							is_pop_type = farmers
+						}				
+					}
+					
+					subtract = 0.95
+				}
+				else = {
+					subtract = 0.75
+				}
+			}			
+		}
+		
+		if = {
+			limit = { 
+				owner ?= { has_journal_entry = je_acw_countdown }
+			}
+			
+			multiply = {
+				value = 3.0
+				desc = "je_acw_countdown"
+			}
+		}
+
+		multiply = { # Illiterate pops participate at 1/10 the rate of fully literate pops
+			desc = "POP_LITERACY"
+			value = literacy_rate
+			add = 0.10
+		}
+	}
+
+	revolution = {
+		possible = {
+			political_movement_support >= 0.05
+		}
+		
+		weight = {
+			value = 100
+		}
+	
+		state_weight = {
+			value = 1
+			if = {
+			   limit = { 
+					is_slave_state = yes
+					NOT = { has_variable = former_free_state }
+			   }	
+			   if = {
+					limit = { 
+						owner ?= {	
+							OR = {
+								has_journal_entry = je_acw_countdown
+								has_law = law_type:law_legacy_slavery
+								has_variable = slavery_recently_enacted
+							}
+							any_scope_state = {
+								OR = {
+								   is_slave_state = no
+								   has_variable = former_free_state	
+								}				
+							}					
+						} 
+					}	  
+					multiply = 0.0
+				}
+				else = {
+					multiply = 0.25
+				}
+			}
+			
+			if = {
+				limit = { is_capital = yes }
+				if = {
+					limit = { owner ?= { has_law = law_type:law_slavery_banned } }
+					multiply = 10.0
+				}
+				else = {
+					multiply = 0.1
+				}
+			}
+		}
+	}
+
+	secession = {
+		possible = {
+			political_movement_support >= 0.05
+			OR = {
+				scope:clout <= 0
+				owner = {
+					OR = {
+						has_journal_entry = je_acw_countdown
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_enacted
+					}
+				}
+			}
+		}	
+	
+		weight = {
+			value = 50
+
+			if = {
+				limit = {
+					owner ?= { has_journal_entry = je_acw_countdown }
+				}
+				add = 50
+			}
+		}	
+		
+		forced_tags = {
+			FSA = {
+				trigger = {
+					owner ?= { has_journal_entry = je_acw_countdown }
+				}
+				weight = 1000
+			}
+			BHT = {
+				trigger = {
+					owner ?= { c:BIC ?= this }
+				}
+				weight = 1000
+			}
+		}
+
+		state_weight = {
+			value = 1
+			if = {
+			   limit = { 
+					is_slave_state = yes
+					NOT = { has_variable = former_free_state }
+			   }	
+			   if = {
+					limit = { 
+						owner ?= {	
+							OR = {
+								has_journal_entry = je_acw_countdown
+								has_law = law_type:law_legacy_slavery
+								has_variable = slavery_recently_enacted
+							}
+							any_scope_state = {
+								OR = {
+								   is_slave_state = no
+								   has_variable = former_free_state	
+								}				
+							}					
+						} 
+					}	  
+					multiply = 0.0
+				}
+				else = {
+					multiply = 0.25
+				}
+			}
+			
+			# New York should be FSA capital
+			if = {
+				limit = { 
+					owner ?= { has_journal_entry = je_acw_countdown }
+					state_region = s:STATE_NEW_YORK
+				}
+				
+				multiply = 10.0
+			}			
+		}		
+	}	
+	
+	additional_radicalism_factors = {
+		if = {
+			limit = {
+				owner.ruler ?= {
+					OR = {
+						has_ideology = ideology:ideology_jacksonian_democrat
+						has_ideology = ideology:ideology_slaver
+					}
+				}
+			}
+			
+			add = {
+				value = 0.1
+				desc = "RULER_IS_PRO_SLAVERY"
+			}
+		}	
+	
+		add = {
+			value = 10
+			subtract = "owner.average_sol_for_slaves"
+			multiply = 0.05
+			max = 0.5
+			min = -0.25
+			desc = "STANDARD_OF_LIVING_FOR_SLAVES"
+		}
+		
+		if = {
+			limit = { 
+				owner ?= { has_journal_entry = je_acw_countdown }
+			}
+			
+			add = {
+				value = 0.2
+				desc = "je_acw_countdown"
+			}
+		}		
+	}
+}
+
+movement_pro_slavery = {
+	category = movement_category_ideological
+
+	ideology = ideology_pro_slavery
+	character_ideologies = {
+		ideology_slaver
+		ideology_jacksonian_democrat
+	}
+	
+	creation_trigger = {
+		NOT = { has_law = law_type:law_slavery_banned }
+	}	
+	creation_weight = {
+		value = 100
+	}	
+	on_created = {
+		add_movement_enthusiasm_modifier = yes
+	}
+	
+	character_support_trigger = {
+		trigger_if = {
+			limit = {
+				is_in_exile_pool = yes
+			}
+			has_ideology = ideology:ideology_slaver
+			has_ideology = ideology:ideology_jacksonian_democrat
+		}
+		trigger_else = {
+			OR = {
+				has_ideology = ideology:ideology_slaver
+				has_ideology = ideology:ideology_jacksonian_democrat
+			}
+			interest_group ?= {
+				has_ideology = ideology:ideology_pro_slavery
+			}
+		}
+	}
+	character_support_weight = {
+		value = 200
+		if = {
+			limit = {
+				OR = {
+					has_ideology = ideology:ideology_slaver
+				}
+			}
+			multiply = {
+				value = 5
+			}
+		}
+	}
+	
+	pop_support_trigger = {
+		state = { is_slave_state = yes }				
+	}
+
+	pop_support_factors = {
+		movement_support_slave_state
+		movement_support_high_literacy
+		movement_support_aristocrats
+		movement_support_farmers
+		movement_support_clergymen
+		movement_support_officers
+		movement_support_clergymen
+		movement_support_je_acw_countdown
+	}
+
+	pop_support_weight = {	
+		add = {
+			value = 9
+			desc = "SLAVE_STATE"
+		}	
+	
+		if = {
+			limit = {
+				is_pop_type = aristocrats
+			}
+			add = {
+				value = 45
+				desc = "POP_ARISTOCRATS"
+			}
+		}	
+		else_if = {
+			limit = {
+				is_pop_type = farmers
+			}
+			add = {
+				value = 15
+				desc = "POP_FARMERS"
+			}
+		}		
+		else_if = {
+			limit = {
+				is_pop_type = clergymen
+			}
+			add = {
+				value = 15
+				desc = "POP_CLERGYMEN"
+			}
+		}
+		else_if = {
+			limit = {
+				is_pop_type = officers
+			}
+			add = {
+				value = 15
+				desc = "POP_OFFICERS"
+			}
+		}
+
+		if = {
+			limit = {
+                this.culture = {
+                    any_scope_pop = {
+                        owner = root.owner
+                        is_pop_type = slaves
+                    }
+                }
+			}
+			multiply = {
+				desc = "CULTURE_ENSLAVED_PERCENT" # TODO: "x percent of this culture is enslaved"
+				value = 1
+
+				subtract = {
+					value = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+									is_pop_type = slaves
+								}
+								add = total_size
+							}
+						}
+					}
+					divide = {
+						value = 0
+						this.culture = {
+							every_scope_pop = {
+								limit = {
+									owner = root.owner
+								}
+								add = total_size
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		if = {
+			limit = { 
+				owner ?= { has_journal_entry = je_acw_countdown }
+			}
+			
+			multiply = {
+				value = 3.0
+				desc = "je_acw_countdown"
+			}		
+		}
+
+		multiply = { # Illiterate pops participate at 1/10 the rate of fully literate pops
+			desc = "POP_LITERACY"
+			value = literacy_rate
+			add = 0.10
+		}
+	}
+	
+	revolution = {
+		possible = {
+			political_movement_support >= 0.05
+		}
+			
+		weight = {
+			value = 100
+		}
+
+		state_weight = {
+			value = 1
+			if = {
+			   limit = { 
+					is_slave_state = no 
+					NOT = { has_variable = former_slave_state }
+			   }	
+			   if = {
+					limit = { 
+						owner ?= {											
+							OR = {
+								has_journal_entry = je_acw_countdown
+								has_law = law_type:law_legacy_slavery
+								has_variable = slavery_recently_abolished
+							}
+							any_scope_state = {
+								OR = {
+								   is_slave_state = yes 
+								   has_variable = former_slave_state			
+								}				
+							}					
+						} 
+					}	  
+					multiply = 0.0
+				}
+				else = {
+					multiply = 0.25
+				}
+			}
+			
+			if = {
+				limit = { is_capital = yes }
+				if = {
+					limit = { owner ?= { NOT = { has_law = law_type:law_slavery_banned } } }
+					multiply = 10.0
+				}
+				else = {
+					multiply = 0.1
+				}
+			}		
+		}
+	}
+	
+	secession = {
+		possible = {
+			political_movement_support >= 0.05
+			OR = {
+				scope:clout <= 0
+				owner = {
+					OR = {
+						has_journal_entry = je_acw_countdown
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}
+				}
+			}
+		}	
+	
+		weight = {
+			value = 10
+
+			if = {
+				limit = {
+					OR = {
+						owner ?= {
+							OR = {
+								has_journal_entry = je_acw_countdown 
+								has_variable = slavery_recently_abolished
+							}						
+						}
+						scope:clout <= 0
+					}
+				}
+				add = 1000
+			}
+		}
+		
+		forced_tags = {
+			CSA = {
+				trigger = {
+					owner ?= { has_journal_entry = je_acw_countdown }
+				}
+				weight = 1000
+			}
+		}
+		
+		state_weight = {
+			value = 1
+			if = {
+			   limit = { 
+					is_slave_state = no 
+					NOT = { has_variable = former_slave_state }
+			   }	
+			   if = {
+					limit = { 
+						owner ?= {											
+							OR = {
+								has_journal_entry = je_acw_countdown
+								has_law = law_type:law_legacy_slavery
+								has_variable = slavery_recently_abolished
+							}
+							any_scope_state = {
+								OR = {
+								   is_slave_state = yes 
+								   has_variable = former_slave_state			
+								}				
+							}					
+						} 
+					}	  
+					multiply = 0.0
+				}
+				else = {
+					multiply = 0.25
+				}
+			}
+			
+			if = {
+				limit = { 
+					owner ?= { has_journal_entry = je_acw_countdown }
+				}
+				
+				if = { # Ensure the union retains Washington DC/Maryland/Delaware in case of southern secession
+					limit = {
+						OR = {
+							state_region = s:STATE_MARYLAND
+							state_region = s:STATE_DELAWARE
+							state_region = s:STATE_DISTRICT_OF_COLUMBIA
+						}					
+					}
+					
+					multiply = 0.0
+				}			
+				else_if = { # Virginia should be CSA capital
+					limit = { 
+						state_region = s:STATE_VIRGINIA
+					}
+					
+					multiply = 10.0
+				}	
+			}	
+		}	
+	}
+	
+	additional_radicalism_factors = {
+		if = {
+			limit = {
+				owner.ruler ?= { has_ideology = ideology:ideology_abolitionist }
+			}
+			
+			add = {
+				value = 0.1
+				desc = "RULER_IS_ANTI_SLAVERY"
+			}
+		}
+	
+		if = {
+			limit = { owner.army_size > 0 }
+			
+			add = {
+				owner = {
+					every_scope_building = {
+						limit = { 
+							is_building_type = building_barracks
+							state = { is_slave_state = yes }
+						}
+						add = this.level
+					}
+				}
+				
+				divide = {
+					value = owner.army_size
+					min = 1
+				}			
+				
+				subtract = 0.5
+				multiply = -1
+				min = 0
+				max = 0.5			
+				desc = "ARMY_FRACTION_IN_SLAVE_STATES"			
+			}			
+		}
+		
+		if = {
+			limit = { owner.navy_size > 0 }		
+
+			add = {
+				owner = {
+					every_scope_building = {
+						limit = { 
+							is_building_type = building_naval_base
+							state = { is_slave_state = yes }
+						}
+						add = this.level
+					}
+				}
+				
+				divide = {
+					value = owner.navy_size
+					min = 1
+				}			
+				
+				subtract = 0.5
+				multiply = -0.5
+				min = 0
+				max = 0.25			
+				desc = "NAVY_FRACTION_IN_SLAVE_STATES"			
+			}	
+		}
+		
+		if = {
+			limit = { 
+				owner ?= { has_journal_entry = je_acw_countdown }
+			}
+			
+			add = {
+				value = 0.2
+				desc = "je_acw_countdown"
+			}
+		}		
+	}
+}

--- a/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_ideological_movements.txt
@@ -770,7 +770,10 @@ movement_pro_slavery = {
 		}
 	
 		if = {
-			limit = { owner.army_size > 0 }
+			limit = { 
+				owner.army_size > 0 
+				owner = { NOT = { has_law = law_type:law_slavery_banned } }
+			}
 			
 			add = {
 				owner = {
@@ -797,7 +800,10 @@ movement_pro_slavery = {
 		}
 		
 		if = {
-			limit = { owner.navy_size > 0 }		
+			limit = { 
+				owner.navy_size > 0
+				owner = { NOT = { has_law = law_type:law_slavery_banned } }
+			}		
 
 			add = {
 				owner = {

--- a/Populist Legal Power/common/political_movements/yMog_PLP_religious_movements.txt
+++ b/Populist Legal Power/common/political_movements/yMog_PLP_religious_movements.txt
@@ -1,0 +1,382 @@
+﻿movement_religious_minority = {
+	category = movement_category_religious
+	
+	ideology = ideology_traditionalist_minoritarian	
+	character_ideologies = {
+		ideology_traditionalist_minoritarian
+	}
+	
+	creation_trigger = {
+		NOT = {
+			c:BIC ?= this
+			has_technology_researched = pan-nationalism
+		}
+	}
+	creation_weight = {
+		value = 200
+	}		
+	on_created = {}
+
+	disband_trigger = {
+		OR = {
+			scope:political_movement ?= {
+				religion = {
+					is_state_religion = root
+				}
+			}
+			AND = {
+				c:BIC ?= this
+				has_technology_researched = pan-nationalism
+			}
+		}
+	}
+
+	on_disbanded = {
+		if = {
+			limit = {
+				owner ?= {
+					c:BIC ?= this
+					has_technology_researched = pan-nationalism
+					NOT = {
+						any_political_movement = { 
+						    is_political_movement_type = movement_muslim_nationalist
+						}
+					}
+				}
+			}
+			owner ?= {
+				create_political_movement = { type = movement_muslim_nationalist }
+			}
+		}
+		if = {
+			limit = {
+				owner ?= {
+					c:BIC ?= this
+					has_technology_researched = pan-nationalism
+					NOT = {
+						any_political_movement = { 
+						    is_political_movement_type = movement_hindu_nationalist
+						}
+					}
+				}
+			}
+			owner ?= {
+				create_political_movement = { type = movement_hindu_nationalist }
+			}
+		}
+	}
+	
+	religion_selection_trigger = {
+		NOT = { is_state_religion = scope:country }
+		NOT = { rel:atheist = this }
+		scope:country = {
+			religion_percent_country = {
+				target = root
+				value >= 0.05
+			}
+		}		
+	}
+	religion_selection_weight = {
+		value = 100
+	}	
+	
+	character_support_trigger = {
+		religion = scope:religion
+		OR = {
+			AND = {
+				owner ?= {
+					has_law = law_type:law_state_atheism
+				}
+				OR = {
+					has_ideology = ideology:ideology_traditionalist
+					has_ideology = ideology:ideology_theocrat
+				}
+			}
+			has_ideology = ideology:ideology_traditionalist_minoritarian
+		}		
+	}
+	character_support_weight = {
+		value = 200
+		if = {
+			limit = {
+				interest_group ?= {
+					is_interest_group_type = ig_devout
+				}
+			}
+			multiply = {
+				value = 2
+			}
+		}
+		if = {
+			limit = {
+				OR = {
+					AND = {
+						owner ?= {
+							has_law = law_type:law_state_atheism
+						}
+						OR = {
+							has_ideology = ideology:ideology_traditionalist
+							has_ideology = ideology:ideology_theocrat
+						}
+					}
+					has_ideology = ideology:ideology_traditionalist_minoritarian
+				}
+			}
+			multiply = {
+				value = 5
+			}
+		}
+		else_if = {
+			limit = {
+				NOT = {
+					interest_group ?= {
+						is_interest_group_type = ig_devout
+					}
+				}
+				OR = {
+					has_progressive_ideology = yes
+					has_socialist_ideology = yes
+				}
+			}
+			multiply = 0.05
+		}
+	}
+	
+	pop_support_trigger = {
+		religion = scope:religion
+	}
+
+	pop_support_factors = {
+		movement_support_poverty
+		movement_support_low_literacy
+		movement_support_religious_discrimination
+		movement_support_clergymen
+		movement_support_aristocrats
+		movement_support_peasants
+		movement_support_corporatism_tech
+	}
+
+	pop_support_weight = {
+		add = {
+			value = 10
+			desc = "POP_BASE_SUPPORT"
+		}	
+		
+		if = {
+			limit = { 
+				standard_of_living < 15
+			}
+			
+			add = {
+				value =	standard_of_living
+				subtract = 15
+				multiply = -5
+				desc = "POP_POVERTY"
+			}
+		}
+
+		if = {
+			limit = {
+				is_pop_type = clergymen
+			}
+			add = {
+				value = 45
+				desc = "POP_CLERGYMEN"
+			}
+		}
+		else_if = {
+			limit = {
+				is_pop_type = aristocrats
+			}
+			add = {
+				value = 10
+				desc = "POP_ARISTOCRATS"
+			}
+		}	
+		else_if = {
+			limit = {
+				is_pop_type = peasants
+			}
+			add = {
+				value = 10
+				desc = "POP_PEASANTS"
+			}
+		}	
+
+		add = { # Weakened by increasing literacy rates
+			desc = "POP_LITERACY"
+			this = {
+				value = literacy_rate
+				multiply = -2
+			}
+		}
+
+		if = {
+			limit = {
+				owner ?= {
+					c:RUS ?= this
+				}
+				culture = cu:polish
+			}
+			multiply = {
+				desc = "POP_POLISH_NATIONALISM"
+				value = 0.05
+			}
+		}
+
+		# Actual conditions relative to their neighbors
+		multiply = {
+			value = 1
+			add = {
+				value = "owner.average_sol_for_religion(owner.religion)"
+				subtract = "owner.average_sol_for_religion(scope:religion)"
+				multiply = 0.05
+			}
+			desc = "STANDARD_OF_LIVING_FOR_RELIGION"
+		}
+		
+		if = {
+			limit = {
+				state = {
+					state_religious_acceptance = {  
+						target = PREV.religion
+						value < religious_acceptance_high
+					}
+				}
+			}
+			multiply = {
+				desc = "POP_RELIGIOUS_DISCRIMINATION"
+				value = 100
+				subtract = pop_acceptance
+				divide = 25 # Maxes out at 4x at 0% acceptance, starts being a liability at 75% acceptance
+			}		
+		}
+		
+		if = {
+			limit = {
+				owner ?= {
+					has_technology_researched = corporatism
+				}
+			}
+			multiply = {
+				value = 1.5
+				desc = "CORPORATISM_TECH"
+			}
+		}
+
+		# Favor cultural movement if necessary
+		if = {
+			limit = {
+				owner = { 
+					any_political_movement = {
+						is_political_movement_type = movement_cultural_minority
+						this.culture ?= root.culture
+					} 
+				}
+			}
+			if = {
+				limit = {
+					owner = { cultural_acceptance_base = { target = culture value <= acceptance_status_1 } }
+				}
+				multiply = 0.1
+			}
+			else_if = {
+				limit = {
+					owner = { cultural_acceptance_base = { target = culture value <= acceptance_status_2 } }
+				}
+				multiply = 0.25	
+			}
+			else_if = {
+				limit = {
+					owner = { cultural_acceptance_base = { target = culture value <= acceptance_status_3 } }
+				}
+				multiply = 0.5	
+			}
+		}	
+	}	
+	
+	secession = {
+		possible = {
+			political_movement_identity_support >= 0.25
+			owner ?= {
+				any_scope_state = {
+					religion_percent_state = {
+						target = scope:political_movement.religion
+						value >= 0.10
+					}
+				}
+			}
+		}
+	
+		weight = {
+			value = 1000
+		}	
+		
+		state_weight = {
+			value = 0
+		
+			if = {
+				limit = { 
+					is_capital = no
+				}
+
+				if = {
+					limit = {
+						religion_percent_state = {
+							target = scope:political_movement.religion
+							value >= 0.75
+						}
+					}
+					add = 250
+				}
+				else_if = {
+					limit = {
+						religion_percent_state = {
+							target = scope:political_movement.religion
+							value >= 0.5
+						}
+					}
+					add = 150
+				}
+				else_if = {
+					limit = {
+						religion_percent_state = {
+							target = scope:political_movement.religion
+							value >= 0.25
+						}
+					}
+					add = 50
+				}
+				else_if = {
+					limit = {
+						religion_percent_state = {
+							target = scope:political_movement.religion
+							value >= 0.1
+						}
+					}
+					add = 10
+				}
+			}			
+		}	
+
+		target_fraction_of_states = {
+			value = political_movement_identity_support
+			add = scope:clout
+			multiply = 3
+			min = 0.15
+			max = 0.75
+		}		
+	}
+	
+	additional_radicalism_factors = {
+		add = {
+			#value = "owner.average_sol"
+			value = "owner.average_sol_for_religion(owner.religion)"
+			subtract = "owner.average_sol_for_religion(scope:religion)"
+			multiply = 0.05
+			max = 0.5
+			min = 0
+			desc = "STANDARD_OF_LIVING_FOR_RELIGION"
+		}
+	}
+}


### PR DESCRIPTION
### Changes

Rework discrimination modifiers
- Open prejudice on national supremacy used as baseline equivalent to 1.7 discrimination modifiers
- Effects are larger, and never removed entirely
- Discriminated pops are more difficult to make loyal

Increased max radicalization from low SOL
Increased max radicalization from discrimination

Movements start radicalizing sooner (50% protesting -> 25% agitating)

Minority movements compare SOL to primary culture/religion average, rather than whole country average


pro/anti-slavery movement attraction
- Compensates for slaves incorrectly being unable to join abolition movements
- Pro-slavery attraction reduced by % of that culture which is enslaved
- Anti-slave trade attraction strongly increased by % of that culture which is enslaved (Gives brazil an abolitionist movement)
- Anti-debt slavery attraction increased by low SOL (Gives EIC and DEI abolitionist movements, as well as other countries once they have empiricism)


### TODO:
- [ ] Figure out what mod this actually goes in
- [ ] % of culture that's enslaved is a bit slow and could be cached
- [ ] Colonial uprisings are too common. Possibly have colonial affairs reduce this
- [ ] Adjust cultural agitation by comparing country SOL to homeland SOL to stop migrants who moved for better SOL from radicalizing too much
- [ ] Parabolic™️ activism momentum. Grey plz do this for me I don't want to