### PR TITLE
RPR: Adjust beasts of burden PM to help the AI use switch to it

### DIFF
--- a/Industries Rework - Ranches/common/production_methods/mog_3_textile_pms.txt
+++ b/Industries Rework - Ranches/common/production_methods/mog_3_textile_pms.txt
@@ -4,7 +4,8 @@
 	building_modifiers = {
 		workforce_scaled = {
 			goods_output_fabric_add = 2
-			goods_output_transportation_add = 2
+			goods_output_transportation_add = 1
+			goods_input_transportation_add = -1
 		}
 	}
 	state_modifiers = {


### PR DESCRIPTION
The AI doesn't evaluate goods shortage reductions between PMs when the good in shortage is both an input and an output. This adjusts the beasts of burden PM to assist the AI in using it when appropriate, without changing the overall production balance.