### PR TITLE
fix AI score for players and colonies

### DIFF
--- a/Subject Interaction Suite/common/diplomatic_actions/MoG_O11_merge_subject.txt
+++ b/Subject Interaction Suite/common/diplomatic_actions/MoG_O11_merge_subject.txt
@@ -108,8 +108,10 @@ merge_subject = {
 					if = {
 						limit = { 
 							scope:target_country = {
-								is_ai = no												# Target country is player
-								has_diplomatic_pact = { who = root type = colony }		# AI will not eat its own Colonies but the player can
+								OR = {
+									is_ai = no												# Target country is player
+									has_diplomatic_pact = { who = root type = colony }		# AI will not eat its own Colonies but the player can
+								}
 							}
 						}
 						multiply = 0
@@ -144,8 +146,10 @@ merge_subject = {
 					if = {
 						limit = { 
 							scope:target_country = {
-								is_ai = no												# Target country is player
-								has_diplomatic_pact = { who = root type = colony }		# AI will not eat its own Colonies but the player can
+								OR = {
+									is_ai = no												# Target country is player
+									has_diplomatic_pact = { who = root type = colony }		# AI will not eat its own Colonies but the player can
+								}
 							}
 						}
 						multiply = 0


### PR DESCRIPTION
It looks like you want to prevent the AI from using the Merge Subject aka the Integrate interaction if the target is the player OR if the target is a colony-type subject.
Currently, as far as I can tell, the AI is only prevented (multiply = 0) from doing so if _both_ of those conditions are true at the same time (i.e. the AI would still be able to Merge non-colonial players, and non-player colonies).
Here I added ORs to the conditions, with the intended effect of preventing any player country, and any colonial subject, from getting Merged by an AI.