### PR TITLE
USU: rescale construction sector employment to the 1.13 vanilla baseline

### DIFF
--- a/USU PEC/common/production_methods/zMoG_USU_construction.txt
+++ b/USU PEC/common/production_methods/zMoG_USU_construction.txt
@@ -16,9 +16,9 @@
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 350		# 500 (150 would-be bureaucrats converted into clerks)
-			building_employment_laborers_add = 1600		# 4000
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 70			# 100 (30 would-be bureaucrats converted into clerks)
+			building_employment_laborers_add = 320		# 800
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -56,10 +56,10 @@ REPLACE_OR_CREATE:pm_iron_frame_buildings = {
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_machinists_add = 150	# 250 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1500		# 3750
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_machinists_add = 30		# 50 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 300		# 750
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -97,10 +97,10 @@ REPLACE_OR_CREATE:pm_steel_frame_buildings = {
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_machinists_add = 350	# 750 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1300		# 3250
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_machinists_add = 70		# 150 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 260		# 650
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -139,11 +139,11 @@ REPLACE_OR_CREATE:pm_arc_welded_buildings = {
 		} 
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_engineers_add = 100
-			building_employment_machinists_add = 350	# 750 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1200
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_engineers_add = 20		# 50
+			building_employment_machinists_add = 70		# 150 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 240		# 600
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1

--- a/Urban Synergy Unleashed/common/production_methods/yMoG_USU_construction.txt
+++ b/Urban Synergy Unleashed/common/production_methods/yMoG_USU_construction.txt
@@ -16,9 +16,9 @@
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 350		# 500 (150 would-be bureaucrats converted into clerks)
-			building_employment_laborers_add = 1600		# 4000
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 70			# 100 (30 would-be bureaucrats converted into clerks)
+			building_employment_laborers_add = 320		# 800
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -55,10 +55,10 @@ REPLACE_OR_CREATE:pm_iron_frame_buildings = {
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_machinists_add = 150	# 250 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1500		# 3750
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_machinists_add = 30		# 50 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 300		# 750
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -95,10 +95,10 @@ REPLACE_OR_CREATE:pm_steel_frame_buildings = {
 		}
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_machinists_add = 350	# 750 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1300		# 3250
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_machinists_add = 70		# 150 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 260		# 650
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1
@@ -136,11 +136,11 @@ REPLACE_OR_CREATE:pm_arc_welded_buildings = {
 		} 
 		
 		level_scaled = {
-			building_employment_bureaucrats_add = 50	# 500
-			building_employment_clerks_add = 300		# 500 (100 would-be bureaucrats converted into clerks)
-			building_employment_engineers_add = 100
-			building_employment_machinists_add = 350	# 750 (50 would-be bureaucrats converted into machinists)
-			building_employment_laborers_add = 1200
+			building_employment_bureaucrats_add = 10	# 100
+			building_employment_clerks_add = 60			# 100 (20 would-be bureaucrats converted into clerks)
+			building_employment_engineers_add = 20		# 50
+			building_employment_machinists_add = 70		# 150 (10 would-be bureaucrats converted into machinists)
+			building_employment_laborers_add = 240		# 600
 		}
 		unscaled = {
 			building_laborers_mortality_mult = 0.1


### PR DESCRIPTION
## Problem

The construction PM employment values in `yMoG_USU_construction.txt` (and the `USU PEC` copy `zMoG_USU_construction.txt`) were derived from **pre-1.13 vanilla** employment, as the inline comments show (`# 500`, `# 4000`, etc.). Vanilla 1.13 cut construction sector employment 5x — e.g. `pm_wooden_buildings` is now 100 bureaucrats / 100 clerks / 800 laborers per level.

As shipped, USU construction sectors employ **2,000 people per level** while producing the 60%-reduced 0.8 construction (wooden). That's **2x current vanilla employment** and **5x the labor per construction point** (2,500 workers/point vs vanilla's 500), whereas construction output and goods inputs both follow the intended uniform "60% reduction" noted in the comments. Construction sectors end up as extreme labor sinks with per-worker output far below every other USU building.

## Fix

Divide all employment values by 5, which:

- keeps USU's bureaucrat→clerk/machinist conversion flavor exactly (same ratios);
- lands on 400 employees per level = 40% of vanilla's 1,000, matching the 60% reduction applied to construction points and inputs;
- restores vanilla per-worker construction output (0.8 construction / 400 workers = 2 / 1,000).

| PM | bureaucrats | clerks | engineers | machinists | laborers | total |
|---|---|---|---|---|---|---|
| wooden | 50 → 10 | 350 → 70 | — | — | 1600 → 320 | 2000 → 400 |
| iron frame | 50 → 10 | 300 → 60 | — | 150 → 30 | 1500 → 300 | 2000 → 400 |
| steel frame | 50 → 10 | 300 → 60 | — | 350 → 70 | 1300 → 260 | 2000 → 400 |
| arc welded | 50 → 10 | 300 → 60 | 100 → 20 | 350 → 70 | 1200 → 240 | 2000 → 400 |

Comments updated to reference the current 1.13 vanilla values. Both the Urban Synergy Unleashed file and the USU PEC compatch copy are changed identically (the compatch keeps its `pec_financial_services` inputs untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)